### PR TITLE
hcl: The Provider configuration will be added to the block even if no…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Fixed
+
+- Now the configuration used (not sensible) when importing will be written to the HCL provider configuration too
+  ([PR #320](https://github.com/cycloidio/terracognita/pull/320))
+
 ## [0.8.1] _2022-08-10_
 
 ### Fixed

--- a/go.sum
+++ b/go.sum
@@ -307,10 +307,6 @@ github.com/cycloidio/terraform-provider-aws v1.60.1-0.20220513132327-e2dbdf90e53
 github.com/cycloidio/terraform-provider-aws v1.60.1-0.20220513132327-e2dbdf90e533/go.mod h1:GMgtgRkfOGOqGyAN7G4oBqD/iFvJOwvPeejv7JNcLpc=
 github.com/cycloidio/terraform-provider-azurerm v1.44.1-0.20220513132617-918497152827 h1:1T2XtaU/ht6ojv8vXD1azNNAJMJWvo7XujnqRq869sY=
 github.com/cycloidio/terraform-provider-azurerm v1.44.1-0.20220513132617-918497152827/go.mod h1:yAWZMAEgx+bUWhfOVBiymy/oxIbobZslFE8I0kjaeKE=
-github.com/cycloidio/tfdocs v0.0.0-20210903075122-31a804b31daf h1:bTxGdxb8uk0orMw726niNd3EYmnwuygtZZidDXZura8=
-github.com/cycloidio/tfdocs v0.0.0-20210903075122-31a804b31daf/go.mod h1:4zRiWOHuVkhb2vatajIFxV5g/AC4W7Zb/0pMF1G0yyA=
-github.com/cycloidio/tfdocs v0.0.0-20220809093344-d999d1c2069e h1:Dc9l5uHbyMzClz0jchr8W0oC6JDQgoRgPDQ/SGAlpIA=
-github.com/cycloidio/tfdocs v0.0.0-20220809093344-d999d1c2069e/go.mod h1:4zRiWOHuVkhb2vatajIFxV5g/AC4W7Zb/0pMF1G0yyA=
 github.com/cycloidio/tfdocs v0.0.0-20220809201117-e73e2388cfa8 h1:wlW3Y1iIdXzi5GQDrzXoVaoKBPi15d+qmJqPCHbs97E=
 github.com/cycloidio/tfdocs v0.0.0-20220809201117-e73e2388cfa8/go.mod h1:4zRiWOHuVkhb2vatajIFxV5g/AC4W7Zb/0pMF1G0yyA=
 github.com/daixiang0/gci v0.2.8/go.mod h1:+4dZ7TISfSmqfAGv59ePaHfNzgGtIkHAhhdKggP1JAc=

--- a/hcl/writer.go
+++ b/hcl/writer.go
@@ -611,7 +611,7 @@ func extractResourceTypeAndName(value string) (string, string) {
 func (w *Writer) setProviderConfig(cat string) {
 	pcfg := w.provider.Configuration()
 	for k, s := range w.provider.TFProvider().Schema {
-		if s.Required {
+		if _, ok := pcfg[k]; s.Required || ok {
 			if _, ok := w.Config[cat]["variable"]; !ok {
 				w.Config[cat]["variable"] = make(map[string]interface{})
 			}

--- a/hcl/writer_test.go
+++ b/hcl/writer_test.go
@@ -24,7 +24,7 @@ func TestNewHCLWriter(t *testing.T) {
 			ctrl = gomock.NewController(t)
 			p    = mock.NewProvider(ctrl)
 		)
-		p.EXPECT().String().Return("aws").Times(2)
+		p.EXPECT().String().Return("aws").Times(3)
 		p.EXPECT().Source().Return("hashicorp/aws")
 		p.EXPECT().TFProvider().Return(aws.Provider())
 		p.EXPECT().Configuration().Return(map[string]interface{}{
@@ -34,7 +34,11 @@ func TestNewHCLWriter(t *testing.T) {
 		hw := hcl.NewWriter(nil, p, &writer.Options{HCLProviderBlock: true})
 		assert.Equal(t, map[string]map[string]interface{}{
 			"hcl": map[string]interface{}{
-				"provider": map[string]interface{}{"aws": map[string]interface{}{}},
+				"provider": map[string]interface{}{
+					"aws": map[string]interface{}{
+						"region": "${var.region}",
+					},
+				},
 				"resource": map[string]map[string]interface{}{},
 				"terraform": map[string]interface{}{
 					"required_providers": map[string]interface{}{
@@ -43,6 +47,11 @@ func TestNewHCLWriter(t *testing.T) {
 						},
 					},
 					"required_version": ">= 1.0",
+				},
+				"variable": map[string]interface{}{
+					"region": map[string]interface{}{
+						"default": "eu-west-1",
+					},
 				},
 			},
 		}, hw.Config)
@@ -244,7 +253,9 @@ func TestHCLWriter_Sync(t *testing.T) {
 				"tc_category": "some-category",
 			}
 			ehcl = `
-provider "aws" { }
+provider "aws" {
+	region = var.region
+}
 
 terraform {
 	required_providers {
@@ -255,14 +266,17 @@ terraform {
 	required_version = ">= 1.0"
 }
 
+variable "region" {
+	default = "eu-west-1"
+}
+
 resource "type" "name" {
   key = "value"
 }
-
 `
 		)
 
-		p.EXPECT().String().Return("aws").Times(2)
+		p.EXPECT().String().Return("aws").Times(3)
 		p.EXPECT().Source().Return("hashicorp/aws")
 		p.EXPECT().TFProvider().Return(aws.Provider())
 		p.EXPECT().Configuration().Return(map[string]interface{}{
@@ -381,7 +395,9 @@ module "test" {
 	type_name_key = "value"
 }
 
-provider "aws" { }
+provider "aws" {
+	region = var.region
+}
 
 terraform {
 	required_providers {
@@ -390,6 +406,10 @@ terraform {
 		}
 	}
 	required_version = ">= 1.0"
+}
+
+variable "region" {
+	default = "eu-west-1"
 }
 
 variable "type_name2_key" {
@@ -421,7 +441,7 @@ variable "type_name_key" {
 }
 `
 		)
-		p.EXPECT().String().Return("aws").Times(2)
+		p.EXPECT().String().Return("aws").Times(3)
 		p.EXPECT().Source().Return("hashicorp/aws")
 		p.EXPECT().TFProvider().Return(aws.Provider())
 		p.EXPECT().Configuration().Return(map[string]interface{}{
@@ -472,7 +492,9 @@ module "test" {
 	type_name_key = "value"
 }
 
-provider "aws" { }
+provider "aws" {
+	region = var.region
+}
 
 terraform {
 	required_providers {
@@ -481,6 +503,10 @@ terraform {
 		}
 	}
 	required_version = ">= 1.0"
+}
+
+variable "region" {
+	default = "eu-west-1"
 }
 
 variable "type_name2_key" {
@@ -492,7 +518,7 @@ variable "type_name_key" {
 }
 `
 		)
-		p.EXPECT().String().Return("aws").Times(2)
+		p.EXPECT().String().Return("aws").Times(3)
 		p.EXPECT().Source().Return("hashicorp/aws")
 		p.EXPECT().TFProvider().Return(aws.Provider())
 		p.EXPECT().Configuration().Return(map[string]interface{}{


### PR DESCRIPTION
…t required

If the provider has a configuration defiend but it's not required it'll setill be added to ease the configuraiton.

As some providers removed the 'required' from the attributes, this was getting less writtng when it actually should because it eases a lot the module configuration